### PR TITLE
FRDA-24: Prevent locale switching links from exposing AP and Images land...

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module ApplicationHelper
 
   def on_scrollspy_page?
@@ -353,4 +354,30 @@ module ApplicationHelper
     "lang-#{I18n.locale}"
   end
 
+  def render_locale_switcher
+    <<-HTML
+      <div class='language-toggle'>
+        #{link_to_if(I18n.locale == :fr, "in english",  params_for_locale_switcher("en"))}
+        |
+        #{link_to_if(I18n.locale == :en, "en français", params_for_locale_switcher("fr"))}
+      </div>
+    HTML
+  end
+  def params_for_locale_switcher(locale)
+    locale_params = {:locale => locale, :result_view => nil}
+    user_params = sanitize_params_for_locale_switcher(params)
+    ap_params = sanitize_params_for_locale_switcher(Rails.application.routes.named_routes.routes[:ap_collection].defaults)
+    images_params = sanitize_params_for_locale_switcher(Rails.application.routes.named_routes.routes[:images_collection].defaults)
+    if [ap_params, images_params].include?(user_params)
+      locale_params
+    else
+      params.merge(locale_params)
+    end
+  end
+  def sanitize_params_for_locale_switcher(p)
+    hwia = HashWithIndifferentAccess.new(p.clone)
+    hwia.delete(:locale)
+    hwia.delete(:result_view)
+    hwia
+  end
 end

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -31,19 +31,7 @@
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
             </a>
-            <div class="language-toggle">
-              <% if I18n.locale == :en %>
-                in english
-              <% else %>
-                <%= link_to "in english", params.merge(:locale => 'en', :result_view => nil) %>
-              <% end %>
-                |
-              <% if I18n.locale == :fr %>
-                en français
-              <% else %>
-                <%= link_to "en français", params.merge(:locale => 'fr', :result_view => nil) %>
-              <% end %>
-            </div>
+            <%= render_locale_switcher.html_safe %>
             <h1><%= t('blacklight.application_name') %></h1>
             <h2><%= t('frda.application_name_subtitle') %></h2>
             <div class="nav-collapse">


### PR DESCRIPTION
...ing page default parameters.

This moves the links from a view into a helper.  The helper method that returns the locale switching links calls a method that is responsible for determining if the current params are an AP or Image landing page.  If it is, it just returns the locale params, if not then it merges the user params and locale params.
