### PR TITLE
FRDA-215: Suppress catalog headings from the XML sent into the ModsDisplay gem

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -9,8 +9,8 @@ class SolrDocument
   self.unique_key = 'id'
 
   mods_xml_source do |model|
-      model[:mods_xml]
-    end
+    model.mods_xml_for_mods_display
+  end
 
   def title(params={})
     length = params[:length] || "long"
@@ -296,7 +296,16 @@ class SolrDocument
     return nil unless self[:mods_xml]
     @mods ||= Stanford::Mods::Record.new.from_str(self[:mods_xml], false)
   end
-  
+
+  def mods_xml_for_mods_display
+    return nil unless self[:mods_xml]
+    xml = Nokogiri::XML(self[:mods_xml]).remove_namespaces!
+    xml.search("//subject[@displayLabel='Catalog heading']").each do |node|
+      node.remove
+    end
+    xml.to_s
+  end
+
    def self.image_dimensions
      options = {:default => "_thumb",
                 :square   => "_square",

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -202,5 +202,14 @@ describe SolrDocument do
       @no_mods_doc.mods.should be_nil
     end
   end
-  
+  describe "mods_xml_for_mods_display" do
+    before(:all) do
+      @xml = "<?xml version='1.0'?><mods><title>This is the first note.</title><subject displayLabel='Catalog heading'>This is a Catalog Heading</subject></mods>"
+      @mods_doc = SolrDocument.new({:id => "12345", :mods_xml => @xml})
+    end
+    it "should remove catalog headings from MODS before sending to the ModsDisplay gem" do
+      expect(@xml).to match(/This is a Catalog Heading/)
+      expect(@mods_doc.mods_xml_for_mods_display).not_to match(/This is a Catalog Heading/)
+    end
+  end
 end


### PR DESCRIPTION
This leaves the regular SolrDocument#mods method alone which is used for
parsing out the Catalog Headings into the area above the main citation.
