### PR TITLE
FRDA-232: Ignore typeOfResource in ModsDisplay configuration.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,7 @@ gem 'blacklight_dates2svg', '~> 0.0.1.beta3'
 gem "coderay"
 
 gem 'stanford-mods'
-gem 'mods_display', '~> 0.2.3'
-
+gem 'mods_display', '~> 0.2.4'
 gem 'bootstrap-datepicker-rails'
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       iso-639
       nokogiri
       nom-xml
-    mods_display (0.2.3)
+    mods_display (0.2.4)
       stanford-mods
     multi_json (1.8.2)
     mysql (2.8.1)
@@ -286,7 +286,7 @@ DEPENDENCIES
   lyberteam-devel (>= 1.0.0)
   lyberteam-gems-devel (>= 1.0.0)
   meta_request
-  mods_display (~> 0.2.3)
+  mods_display (~> 0.2.4)
   mysql (= 2.8.1)
   net-ssh-krb
   rails (= 3.2.16)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -18,6 +18,9 @@ class CatalogController < ApplicationController
       hierarchical_link true
       link :catalog_index_path, q: '"%value%"'
     end
+    resource_type do
+      ignore!
+    end
     collection do
       ignore!
     end


### PR DESCRIPTION
We have decided only to ignore typeOfResource for the time being
but may ignore additional elements used in the construction of
other top level sections of the MODS metadata.

This required a patch update to the ModsDisplay gem to fix a
configuration issue with typeOfResource.
