### PR TITLE
Strip out quotes from user query parameter when doing an 'In Speeches By' search.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -413,7 +413,7 @@ class CatalogController < ApplicationController
 
   def search_within_speeches(solr_params, user_params)
     unless user_params["speeches"].blank? and user_params["by-speaker"].blank?
-      solr_params[:q] = "spoken_text_ftsimv:\"aaa#{user_params['by-speaker']}zzz #{user_params['q']}\"~10000"
+      solr_params[:q] = "spoken_text_ftsimv:\"aaa#{user_params['by-speaker']}zzz #{user_params['q'].gsub('"','')}\"~10050"
       solr_params[:defType] = "lucene"
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -22,6 +22,12 @@ describe CatalogController do
         controller.send(:search_within_speeches, @solr_params, @user_params)
         expect(@solr_params[:q]).to match /\"~(\d+)$/
       end
+      it "should remove quotes in the user query param" do
+        user_params = {"q" => '"HEY, this is a phrase"', "speeches" => "1", "by-speaker" => @speaker}
+        controller.send(:search_within_speeches, @solr_params, user_params)
+        expect(user_params["q"]).to eq '"HEY, this is a phrase"'
+        expect(@solr_params[:q]).not_to match user_params["q"]
+      end
     end
     describe "exclude_highlighting" do
       it "should turn highlighting off and not return any rows for the home page" do


### PR DESCRIPTION
The query sent into solr is already quoted and we do not want phrase searches for this anyway (as it will most likely reduce recall).

Also bumping up the boost value by 50 for relevancy purposes.
