### PR TITLE
Comment out genre linking.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -11,9 +11,13 @@ class CatalogController < ApplicationController
   include ModsDisplay::ControllerExtension
 
   configure_mods_display do
-    genre do
-      link :search_link_from_facet_field, :field => "genre_ssim", :value => "%value%"
-    end
+    # Removing genre links per FRDA-191. I am keeping this commented out
+    # as a refernece to how we used the search_link_from_facet_field
+    # method in case we would like to re-link genre in the future.
+
+    # genre do
+    #   link :search_link_from_facet_field, :field => "genre_ssim", :value => "%value%"
+    # end
     subject do
       hierarchical_link true
       link :catalog_index_path, q: '"%value%"'

--- a/spec/integration/catalog_spec.rb
+++ b/spec/integration/catalog_spec.rb
@@ -73,8 +73,9 @@ describe("Search Pages",:type=>:request,:integration=>true) do
   it "should show an Images detail page" do
     visit catalog_path(:id=>'bb018fc7286')
     page.should have_content("le 14.e juillet 1790 : [estampe]")
-    page.should have_xpath("//img[contains(@src, \"bb018fc7286/T0000001_thumb.jpg\")]")    
-    page.should have_xpath("//a[contains(@href, \"en/catalog?f%5Bgenre_ssim%5D%5B%5D=Picture\")]")
+    page.should have_xpath("//img[contains(@src, \"bb018fc7286/T0000001_thumb.jpg\")]")
+    page.should have_xpath("//dt", :text => "Genre")
+    page.should have_xpath("//dd", :text => "Picture")
   end
 
   it "should include a colon in an Images detail page title when there is a Mods subTitle" do


### PR DESCRIPTION
FRDA-191

The undesirable genre suffixes have been removed from the solr documents but not the original MODS itself.  This is causing the genre links to get zero results.  Linking the genre from the records was never specified so it's not an issue to remove the links.
